### PR TITLE
Code coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,4 +34,5 @@ jobs:
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CodeClimateReporterId }}
         with:
+          coverageCommand: npx jest --coverage
           debug: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: build
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
+on: [push, pull_request]
 
 jobs:
   # test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,5 +34,5 @@ jobs:
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CodeClimateReporterId }}
         with:
-          coverageCommand: npm coverage
+          coverageCommand: npm run coverage
           debug: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,20 +6,20 @@ jobs:
   test:
     strategy:
       matrix:
-        platform: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, macOS-latest]
         node: [12, 10]
-    name: test/node ${{ matrix.node-version }}
+    name: Test ${{ matrix.os }}/${{ matrix.node }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@master
-      # - uses: actions/setup-node@master
-      #   with:
-      #     node-version: ${{ matrix.node-version }}
-      # - run: npm install
-      # - run: npm run build --if-present
-      # - run: npm test
-      #   env:
-      #     CI: true
+      - uses: actions/setup-node@master
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm install
+      - run: npm run build --if-present
+      - run: npm test
+        env:
+          CI: true
   coverage:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,25 +3,24 @@ name: build
 on: [push, pull_request]
 
 jobs:
-  # test:
-    # strategy:
-    #   matrix:
-    #     platform: [ubuntu-latest, macOS-latest]
-    #     node: [12.x, 10.x]
-    # name: test/node ${{ matrix.node-version }}
-    # runs-on: ${{ matrix.os }}
-    # steps:
-    #   - uses: actions/checkout@master
-    #   - uses: actions/setup-node@master
-    #     with:
-    #       node-version: ${{ matrix.node-version }}
-    #   - run: npm install
-    #   - run: npm run build --if-present
-    #   - run: npm test
-    #     env:
-    #       CI: true
+  test:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macOS-latest]
+        node: [12.x, 10.x]
+    name: test/node ${{ matrix.node-version }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@master
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm run build --if-present
+      - run: npm test
+        env:
+          CI: true
   coverage:
-    # needs: [test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           node-version: '12'
       - run: npm install
-      - uses: paambaati/codeclimate-action@v2.2.4
+      - uses: paambaati/codeclimate-action@v2.4.0
         env:
           CC_TEST_REPORTER_ID: 73e5c9192cc4ce120a00d08984a41341c6c280822a15fd878936d410b193e809
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,26 +1,31 @@
 name: build
-on: [push]
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
 jobs:
-  test:
-    strategy:
-      matrix:
-        platform: [ubuntu-latest, macOS-latest]
-        node: [12.x, 10.x]
-    name: test/node ${{ matrix.node-version }}
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-node@master
-        with:
-          node-version: ${{ matrix.node-version }}
-      - run: npm install
-      - run: npm run build --if-present
-      - run: npm test
-        env:
-          CI: true
+  # test:
+    # strategy:
+    #   matrix:
+    #     platform: [ubuntu-latest, macOS-latest]
+    #     node: [12.x, 10.x]
+    # name: test/node ${{ matrix.node-version }}
+    # runs-on: ${{ matrix.os }}
+    # steps:
+    #   - uses: actions/checkout@master
+    #   - uses: actions/setup-node@master
+    #     with:
+    #       node-version: ${{ matrix.node-version }}
+    #   - run: npm install
+    #   - run: npm run build --if-present
+    #   - run: npm test
+    #     env:
+    #       CI: true
   coverage:
-    needs: [test]
-    name: coverage
+    # needs: [test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,9 @@ jobs:
         with:
           node-version: '12'
       - run: npm install
-      - uses: paambaati/codeclimate-action@v2.4.0
+      - name: Test and publish code coverage
+        uses: paambaati/codeclimate-action@v2.4.0
         env:
-          CC_TEST_REPORTER_ID: 73e5c9192cc4ce120a00d08984a41341c6c280822a15fd878936d410b193e809
+          CC_TEST_REPORTER_ID: ${{ secrets.CodeClimateReporterId }}
         with:
-          coverageCommand: npx jest --coverage
+          debug: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,5 +34,5 @@ jobs:
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CodeClimateReporterId }}
         with:
-          coverageCommand: npx jest --coverage
+          coverageCommand: npm coverage
           debug: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,26 +7,26 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macOS-latest]
-        node: [12.x, 10.x]
+        node: [12, 10]
     name: test/node ${{ matrix.node-version }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@master
-      - uses: actions/setup-node@master
-        with:
-          node-version: ${{ matrix.node-version }}
-      - run: npm install
-      - run: npm run build --if-present
-      - run: npm test
-        env:
-          CI: true
+      # - uses: actions/setup-node@master
+      #   with:
+      #     node-version: ${{ matrix.node-version }}
+      # - run: npm install
+      # - run: npm run build --if-present
+      # - run: npm test
+      #   env:
+      #     CI: true
   coverage:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-node@master
         with:
-          node-version: '12'
+          node-version: "12"
       - run: npm install
       - name: Test and publish code coverage
         uses: paambaati/codeclimate-action@v2.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, macos-latest]
         node: [12, 10]
     name: Test ${{ matrix.os }}/${{ matrix.node }}
     runs-on: ${{ matrix.os }}
@@ -21,6 +21,7 @@ jobs:
         env:
           CI: true
   coverage:
+    name: Test and publish test coverage
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -28,8 +29,7 @@ jobs:
         with:
           node-version: "12"
       - run: npm install
-      - name: Test and publish code coverage
-        uses: paambaati/codeclimate-action@v2.4.0
+      - uses: paambaati/codeclimate-action@v2.4.0
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CodeClimateReporterId }}
         with:

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "git+https://github.com/Lambda-School-Labs/Workout-Builder-be.git"
   },
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/Lambda-School-Labs/Workout-Builder-be/issues"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "server": "nodemon index.js",
     "start": "node index.js",
-    "test": "jest --watch",
+    "test": "jest --detectOpenHandles --forceExit",
     "coverage": "jest --coverage --detectOpenHandles --forceExit || true"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "server": "nodemon index.js",
     "start": "node index.js",
     "test": "jest --watch",
-    "coverage": "jest --coverage --detectOpenHandles"
+    "coverage": "jest --coverage --detectOpenHandles --forceExit"
   },
   "jest": {
     "testEnvironment": "node",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "server": "nodemon index.js",
     "start": "node index.js",
-    "test": "jest --watch"
+    "test": "jest --watch",
+    "coverage": "jest --coverage --detectOpenHandles"
   },
   "jest": {
     "testEnvironment": "node",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "server": "nodemon index.js",
     "start": "node index.js",
     "test": "jest --watch",
-    "coverage": "jest --coverage --detectOpenHandles --forceExit"
+    "coverage": "jest --coverage --detectOpenHandles --forceExit || true"
   },
   "jest": {
     "testEnvironment": "node",


### PR DESCRIPTION
# Description
Fixed code coverage run using GitHub actions.

- Runs a coverage job that will publish results to Code Climate
- Stores the Code Climate reported ID as a GitHub secret
- Fixed matrixed test run by adding `--forceExit` argument to Jest. Note: This means that your tests are holding on to some resources, need to track this down, fix it and remove the `--forceExit` flag.
- Also fixed usage of variables in the matrixed test run
